### PR TITLE
fixed python3 compability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.vscode/*
+**/.DS_Store
+*.pyc
+*.tgz
+reports
+cloud_backup/.vscode/
+cloud_backup/local/
+cloud_backup/metadata/
+backupconfig.json

--- a/bin/refresh.py
+++ b/bin/refresh.py
@@ -87,6 +87,10 @@ if myEntity == 'safe' or myEntity == 'all':  # reload all entities
     logger.info('reloading all entities ...')
     # get rest response and content
     response, content = rest.simpleRequest('/servicesNS/-/-/admin', sessionKey=sessionKey, method='GET')
+    
+    if sys.version_info[0] >= 3: 
+        content = content.decode()
+
     for line in content.split('\n'):  # loop throught the content
         logger.info('line: %s ' % line)
         if '_reload' in line:  # _reload link found

--- a/bin/refresh.py
+++ b/bin/refresh.py
@@ -80,6 +80,11 @@ logger.info('using namespace: %s ' % namespace)
 # setting up empty output list
 myList = []
 
+# # debugcode
+# import sys, os
+# sys.path.append(os.path.join(os.environ['SPLUNK_HOME'],'etc','apps','SA-VSCode','bin'))
+# import splunk_debug as dbg
+# dbg.enable_debugging(timeout=25)
 
 # getting all the _reload links form the response content
 reloadLinks = []  # set empty list
@@ -125,7 +130,8 @@ else:  # reload all entities
     myREST = '/servicesNS/-/-/admin/%s' % myEntity
     logger.info('getting reload link from : %s' % myREST)
     response, content = rest.simpleRequest(myREST, sessionKey=sessionKey, method='GET')
-    for line in content.split('\n'):  # loop throught the content
+    contentnew = content.decode()
+    for line in contentnew.split('\n'):  # loop throught the content
         logger.info('line: %s ' % line)
         if '_reload' in line:  # _reload link found
             reloadLink = re.findall(r'href\=\"(.+?)\"', line)  # getting the links

--- a/default/app.conf
+++ b/default/app.conf
@@ -12,7 +12,7 @@ label = Add-on for Splunk to refresh the config
 [launcher]
 author = MuS
 description = custom search command to refresh Splunk config on the fly
-version = 2.3.0
+version = 2.3.1
 
 [package]
 check_for_updates = 1

--- a/default/commands.conf
+++ b/default/commands.conf
@@ -4,3 +4,4 @@ passauth = true
 enableheader = true
 local = true
 generating = true
+python.version = python3


### PR DESCRIPTION
when python3 is activated by default from splunk version 8.1 upwards the refresh.py was crashing in line 90 at content.split('\n'). content is returned in bytes, not in string.

These 2 lines should fix the issue. 